### PR TITLE
Ensure Color Chain initializes after DOM load

### DIFF
--- a/content/juegos.md
+++ b/content/juegos.md
@@ -318,9 +318,6 @@ Bienvenido a mi colección de juegos web. Aquí encontrarás diferentes juegos d
     }
 }
 </style>
-<script src="/js/color-chain-game.js"></script>
-
-
 <script src="/js/color-chain-game.js" defer></script>
 
 <h2>🏆 Puntuaciones y Récords</h2>

--- a/static/js/color-chain-game.js
+++ b/static/js/color-chain-game.js
@@ -249,7 +249,7 @@ function initMenu() {
 }
 
 
-initMenu();
+document.addEventListener('DOMContentLoaded', initMenu);
 
 
 // Función global para controlar el audio


### PR DESCRIPTION
## Summary
- Run Color Chain game menu setup after DOMContentLoaded
- Remove duplicate script tag in `juegos` page, keeping deferred load

## Testing
- `hugo` *(fails: ERROR => hugo v0.146.0 or greater is required for hugo-PaperMod to build)*

------
https://chatgpt.com/codex/tasks/task_e_6894f9ec53cc83219311524dc7ea6718